### PR TITLE
Add simple quiz webpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # codex
 這是我的 Codex 專案。
+
+## 在本地端開啟練習題頁面
+1. 在專案目錄啟動簡易伺服器：
+   ```bash
+   python3 -m http.server
+   ```
+2. 在瀏覽器開啟 `http://localhost:8000/index.html`。

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Quiz</title>
+</head>
+<body>
+    <h1>Practice Quiz</h1>
+    <form id="quiz-form"></form>
+    <button id="submit-btn">Submit</button>
+    <div id="result"></div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/questions.json
+++ b/questions.json
@@ -1,0 +1,19 @@
+{
+  "questions": [
+    {
+      "question": "What is the capital of France?",
+      "options": ["Berlin", "Madrid", "Paris", "Rome"],
+      "answer": "Paris"
+    },
+    {
+      "question": "Which planet is known as the Red Planet?",
+      "options": ["Earth", "Mars", "Jupiter", "Saturn"],
+      "answer": "Mars"
+    },
+    {
+      "question": "Which language is used to style web pages?",
+      "options": ["HTML", "Python", "CSS", "C++"],
+      "answer": "CSS"
+    }
+  ]
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,45 @@
+document.addEventListener('DOMContentLoaded', () => {
+    fetch('questions.json')
+        .then(res => res.json())
+        .then(data => {
+            const form = document.getElementById('quiz-form');
+            data.questions.forEach((q, idx) => {
+                const fieldset = document.createElement('fieldset');
+                const legend = document.createElement('legend');
+                legend.textContent = q.question;
+                fieldset.appendChild(legend);
+                q.options.forEach(opt => {
+                    const label = document.createElement('label');
+                    const radio = document.createElement('input');
+                    radio.type = 'radio';
+                    radio.name = `question${idx}`;
+                    radio.value = opt;
+                    label.appendChild(radio);
+                    label.appendChild(document.createTextNode(opt));
+                    fieldset.appendChild(label);
+                    fieldset.appendChild(document.createElement('br'));
+                });
+                form.appendChild(fieldset);
+            });
+        });
+
+    document
+        .getElementById('submit-btn')
+        .addEventListener('click', e => {
+            e.preventDefault();
+            fetch('questions.json')
+                .then(res => res.json())
+                .then(data => {
+                    let score = 0;
+                    data.questions.forEach((q, idx) => {
+                        const selector = `input[name=question${idx}]:checked`;
+                        const selected = document.querySelector(selector);
+                        if (selected && selected.value === q.answer) {
+                            score++;
+                        }
+                    });
+                    document.getElementById('result').textContent =
+                        `You scored ${score} of ${data.questions.length}.`;
+                });
+        });
+});


### PR DESCRIPTION
## Summary
- set up `index.html` to display a quiz form
- add `script.js` to load questions from `questions.json` and check answers
- provide a `questions.json` example
- update `README.md` with instructions to open the quiz locally

## Testing
- `jq . questions.json`

------
https://chatgpt.com/codex/tasks/task_e_6867dff34cf0832f85a6b0ef528fe5ee